### PR TITLE
Fix for 3152

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Edit/__test__/Edit.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Edit/__test__/Edit.spec.tsx
@@ -8,6 +8,8 @@ import {
   useTopicConfig,
   useTopicDetails,
   useUpdateTopic,
+  useIncreaseTopicPartitionsCount,
+  useUpdateTopicReplicationFactor,
 } from 'lib/hooks/api/topics';
 import { internalTopicPayload, topicConfigPayload } from 'lib/fixtures/topics';
 
@@ -25,14 +27,12 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock('components/Topics/Topic/Edit/DangerZone/DangerZone', () => () => (
-  <>DangerZone</>
-));
-
 jest.mock('lib/hooks/api/topics', () => ({
   useTopicDetails: jest.fn(),
   useTopicConfig: jest.fn(),
   useUpdateTopic: jest.fn(),
+  useIncreaseTopicPartitionsCount: jest.fn(),
+  useUpdateTopicReplicationFactor: jest.fn(),
 }));
 
 const updateTopicMock = jest.fn();
@@ -59,20 +59,27 @@ describe('Edit Component', () => {
       isLoading: false,
       mutateAsync: updateTopicMock,
     }));
+    (useIncreaseTopicPartitionsCount as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      mutateAsync: {},
+    }));
+    (useUpdateTopicReplicationFactor as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      mutateAsync: {},
+    }));
     renderComponent();
   });
 
   it('renders DangerZone component', () => {
-    expect(screen.getByText(`DangerZone`)).toBeInTheDocument();
+    expect(screen.getByText(`Danger Zone`)).toBeInTheDocument();
   });
 
   it('submits form correctly', async () => {
-    renderComponent();
     const btn = screen.getAllByText(/Update topic/i)[0];
-    const field = screen.getByRole('spinbutton', {
-      name: 'Min In Sync Replicas Min In Sync Replicas',
+    const field = screen.getByRole('button', {
+      name: '1 day',
     });
-    await userEvent.type(field, '1');
+    await userEvent.click(field);
     await userEvent.click(btn);
     expect(updateTopicMock).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('../');

--- a/kafka-ui-react-app/src/lib/__test__/yupExtended.spec.ts
+++ b/kafka-ui-react-app/src/lib/__test__/yupExtended.spec.ts
@@ -1,4 +1,4 @@
-import { isValidJsonObject } from 'lib/yupExtended';
+import { isValidJsonObject, topicFormValidationSchema} from 'lib/yupExtended';
 
 describe('yup extended', () => {
   describe('isValidJsonObject', () => {
@@ -19,6 +19,39 @@ describe('yup extended', () => {
 
     it('returns true for valid JSON object', () => {
       expect(isValidJsonObject('{ "foo": "bar" }')).toBeTruthy();
+    });
+  });
+});
+
+describe('topicFormValidationSchema', () => {
+  describe('minInSyncReplicas', () => {
+    it('should fail if minInSyncReplicas > replicationFactor', async () => {
+      const formData = {
+        name: 'my-topic',
+        partitions: 3,
+        replicationFactor: 2,
+        minInSyncReplicas: 3,
+        cleanupPolicy: 'compact',
+      };
+
+      await expect(
+        topicFormValidationSchema.validate(formData)
+      ).rejects.toThrow(
+        /Min In Sync Replicas must be less than or equal to Replication Factor/
+      );
+    });
+    it('should pass if minInSyncReplicas <= replicationFactor', async () => {
+      const formData = {
+        name: 'my-topic',
+        partitions: 3,
+        replicationFactor: 3,
+        minInSyncReplicas: 2,
+        cleanupPolicy: 'delete',
+      };
+
+      await expect(topicFormValidationSchema.validate(formData)).resolves.toBe(
+        formData
+      );
     });
   });
 });

--- a/kafka-ui-react-app/src/lib/yupExtended.ts
+++ b/kafka-ui-react-app/src/lib/yupExtended.ts
@@ -63,33 +63,68 @@ export function cacheTest(
 
 yup.addMethod(yup.StringSchema, 'isJsonObject', isJsonObject);
 
-export const topicFormValidationSchema = yup.object().shape({
-  name: yup
-    .string()
-    .max(249)
-    .required()
-    .matches(
-      TOPIC_NAME_VALIDATION_PATTERN,
-      'Only alphanumeric, _, -, and . allowed'
+export const topicFormValidationSchema = yup.object().shape(
+  {
+    name: yup
+      .string()
+      .max(249)
+      .required()
+      .matches(
+        TOPIC_NAME_VALIDATION_PATTERN,
+        'Only alphanumeric, _, -, and . allowed'
+      ),
+    partitions: yup
+      .number()
+      .min(1)
+      .max(2147483647)
+      .required()
+      .typeError('Number of partitions is required and must be a number'),
+    replicationFactor: yup.lazy((value) => {
+      if (value && value !== '') {
+        return yup.number().when('minInSyncReplicas', {
+          is: (val) => val && val !== '',
+          then: () =>
+            yup
+              .number()
+              .min(
+                yup.ref('minInSyncReplicas'),
+                'Replication Factor must be greater than Min In Sync Replicas'
+              )
+              .required(),
+          otherwise: () => yup.number().min(0),
+        });
+      }
+      return yup.string();
+    }),
+    minInSyncReplicas: yup.lazy((value) => {
+      if (value && value !== '') {
+        return yup.number().when('replicationFactor', {
+          is: (val) => val && val !== '',
+          then: () =>
+            yup
+              .number()
+              .max(
+                yup.ref('replicationFactor'),
+                'Min In Sync Replicas must be less than or equal to Replication Factor'
+              )
+              .required(),
+          otherwise: () => yup.number().max(0),
+        });
+      }
+      return yup.string();
+    }),
+    cleanupPolicy: yup.string().required(),
+    retentionMs: yup.string(),
+    retentionBytes: yup.number(),
+    maxMessageBytes: yup.string(),
+    customParams: yup.array().of(
+      yup.object().shape({
+        name: yup.string().required('Custom parameter is required'),
+        value: yup.string().required('Value is required'),
+      })
     ),
-  partitions: yup
-    .number()
-    .min(1)
-    .max(2147483647)
-    .required()
-    .typeError('Number of partitions is required and must be a number'),
-  replicationFactor: yup.string(),
-  minInSyncReplicas: yup.string(),
-  cleanupPolicy: yup.string().required(),
-  retentionMs: yup.string(),
-  retentionBytes: yup.number(),
-  maxMessageBytes: yup.string(),
-  customParams: yup.array().of(
-    yup.object().shape({
-      name: yup.string().required('Custom parameter is required'),
-      value: yup.string().required('Value is required'),
-    })
-  ),
-});
+  },
+  ['minInSyncReplicas', 'replicationFactor']
+);
 
 export default yup;


### PR DESCRIPTION
- Updated yupExtended.ts: Updated schema for minInSyncReplicas and replicationFactor to be mutually exculsive and conditionally maintain replicationFactor >= minInSyncReplicas.
- Added unit tests for validation updated logic in yupExtended.ts.
- Fixed failing test cases in Edit.spec.ts
 - Problem : This test case just checks if submit is possible after changes, the test case was changing value for minInSyncReplicas. Due to this the new validation logic was being triggered, the logic failed since it looks like replicationFactor is included in DangerZone which is mocked out as part of this test.
 - Fix : Removed stubbing/mocking for DangerZone, making sure it renders. Mocked dependencies for DangerZone. Triggering change to a different field than minInSyncReplicas.

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
